### PR TITLE
fix paths to other guides

### DIFF
--- a/src/_guides/bump-sh-tutorials/mocking-with-microcks.md
+++ b/src/_guides/bump-sh-tutorials/mocking-with-microcks.md
@@ -37,7 +37,7 @@ Once we've got Microcks loaded in the browser, click on "Importers", and click t
 
 ![The "Direct upload artifact" modal window](/images/guides/mocking-with-microcks/upload-modal.png)
 
-The modal that pops up is asking for an Artifact, which is referring to various documents that could describe an API, like a [Postman Collection](./try-requests-in-postman.md) and other "API description documents". We can pop our OpenAPI in there, which is the same `openapi.yaml` document that you deploy to Bump.sh.
+The modal that pops up is asking for an Artifact, which is referring to various documents that could describe an API, like a [Postman Collection](_guides/bump-sh-tutorials/try-requests-in-postman.md) and other "API description documents". We can pop our OpenAPI in there, which is the same `openapi.yaml` document that you deploy to Bump.sh.
 
 The question about primary or secondary artifacts can be ignored for now.
 

--- a/src/_guides/bump-sh-tutorials/testing-with-microcks.md
+++ b/src/_guides/bump-sh-tutorials/testing-with-microcks.md
@@ -5,7 +5,7 @@ excerpt: Make sure your APIs are doing what you expect them too with contract te
 date: 2024-08-24
 ---
 
-After you've gone through planning and designing an excellent API, published your documentation to Bump.sh, got loads of useful feedback from stakeholders by [mocking your API](mocking-with-microcks.md), and built (or generated) an API implementation, you're pretty close to releasing the API into the wild.
+After you've gone through planning and designing an excellent API, published your documentation to Bump.sh, got loads of useful feedback from stakeholders by [mocking your API](_guides/bump-sh-tutorials/mocking-with-microcks.md), and built (or generated) an API implementation, you're pretty close to releasing the API into the wild.
 
 Before you send this API out into the world, how do you know that the documentation and the API are actually... correct? Is the API doing something the documentation doesn't mention? Is the documentation saying the API works differently to how it actually works? 
 
@@ -21,7 +21,7 @@ Even if you’re not using the API design first workflow, if you have OpenAPI an
 
 ## Step 1: Set up Microcks
 
-First you'll need to get Microcks set up, and that can be done with Docker, or it could be a hosted installation that lets your whole team/organization work with it. Setting Microcks up for testing is the same process as setting [Microcks up for mocking](mocking-with-microcks.md), so follow that guide and come back here when you're done.
+First you'll need to get Microcks set up, and that can be done with Docker, or it could be a hosted installation that lets your whole team/organization work with it. Setting Microcks up for testing is the same process as setting [Microcks up for mocking](_guides/bump-sh-tutorials/mocking-with-microcks.md), so follow that guide and come back here when you're done.
 
 [](/images/guides/mocking-with-microcks/microcks-api-view.png)
 


### PR DESCRIPTION
Changed path to other files to make the `internal_markdown_links` plugin happy.

Cheers!